### PR TITLE
내가 개설한 강의 리스트 불러오기 api에 수강생 수 추가하기

### DIFF
--- a/src/main/java/com/nemo/oceanAcademy/domain/classroom/application/dto/ClassroomResponseDto.java
+++ b/src/main/java/com/nemo/oceanAcademy/domain/classroom/application/dto/ClassroomResponseDto.java
@@ -52,6 +52,9 @@ public class ClassroomResponseDto {
     // 강의실 활성화 여부 (조회 시 반환)
     private Boolean isActive;
 
+    // 강의실 수강 인원
+    private long studentCount;
+
     // Classroom 엔티티를 기반으로 생성하는 생성자 추가
     public ClassroomResponseDto(Classroom classroom) {
         this.id = classroom.getId();  // 강의실 아이디
@@ -67,5 +70,11 @@ public class ClassroomResponseDto {
         this.announcement = classroom.getAnnouncement();  // 강의 공지
         this.bannerImagePath = classroom.getBannerImagePath();  // 배너 이미지 경로
         this.isActive = classroom.getIsActive();  // 강의실 활성화 여부
+    }
+
+    // 수강 인원을 설정하는 생성자
+    public ClassroomResponseDto(Classroom classroom, long studentCount) {
+        this(classroom);
+        this.studentCount = studentCount;
     }
 }

--- a/src/main/java/com/nemo/oceanAcademy/domain/classroom/dataAccess/repository/ClassroomRepository.java
+++ b/src/main/java/com/nemo/oceanAcademy/domain/classroom/dataAccess/repository/ClassroomRepository.java
@@ -30,9 +30,12 @@ public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
     List<ClassroomResponseDto> findClassroomsByCategoryId(@Param("categoryId") Integer categoryId, Pageable pageable);
 
     // 내가 개설한 강의 조회
-    @Query("SELECT new com.nemo.oceanAcademy.domain.classroom.application.dto.ClassroomResponseDto(c) " +
-            "FROM Classroom c WHERE c.user.id = :userId " +
-            "AND (:categoryId IS NULL OR c.category.id = :categoryId)")
+    @Query("SELECT new com.nemo.oceanAcademy.domain.classroom.application.dto.ClassroomResponseDto(c, COUNT(p)) " +
+            "FROM Classroom c " +
+            "LEFT JOIN Participant p ON c.id = p.classroom.id " +
+            "WHERE c.user.id = :userId " +
+            "AND (:categoryId IS NULL OR c.category.id = :categoryId) " +
+            "GROUP BY c.id")
     List<ClassroomResponseDto> findCreatedClassrooms(@Param("categoryId") Integer categoryId, @Param("userId") String userId, Pageable pageable);
 
     // 상위 10개 강의 조회


### PR DESCRIPTION
### Description

- 내가 개설한 강의 리스트 불러오기 api에 수강생 수 추가 (/api/classes)

### Related Issues

-

### Changes Made

1. `/api/classes` GET 요청의 응답 DTO를 변경했습니다.
2. ?target=created일 때 수강생 수를 계산해서 추가했습니다.
3. 변경 내용을 [API 문서](https://goormkdx.notion.site/ee8311b2283341e88b87d67cfeb3f035?v=17065ffd107746bab7010e33ae5cff33&pvs=4)에 적용했습니다.

### Screenshots or Video

-

### Testing

1. 포스트맨으로 테스트했습니다.

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

-
